### PR TITLE
Merge changes in dev/sanity-migration to master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+# migrations directory -- this is linked from project root to play nice with sanity's cli
+/migrations

--- a/lib/sanity/migrations/ensureSingletons.ts
+++ b/lib/sanity/migrations/ensureSingletons.ts
@@ -1,0 +1,35 @@
+import type { Mutation } from "sanity/migrate";
+
+import { defineMigration, createIfNotExists, delete_ } from "sanity/migrate";
+
+/**
+ * Object containing key-value pairs of document types and assigned ids.
+ */
+type SingletonMap = { [key: string]: string };
+
+const singletonDocuments: SingletonMap = {
+	settings: "settings",
+};
+
+export default defineMigration({
+	title: "Ensure singtleton documents are kept as singletons.",
+	documentTypes: Object.keys(singletonDocuments),
+	migrate: {
+		document: (doc, context) => {
+			const mutations: Mutation[] = [];
+
+			if (doc._id !== singletonDocuments[doc._type]) {
+				mutations.push(delete_(doc._id));
+			}
+
+			mutations.push(
+				createIfNotExists({
+					_type: doc._type,
+					_id: singletonDocuments[doc._type],
+				}),
+			);
+
+			return mutations;
+		},
+	},
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"pre-commit:setup": "ln -f scripts/pre-commit .git/hooks/pre-commit; chmod +x .git/hooks/pre-commit",
 		"sanity-typegen": "scripts/sanity-typegen",
 		"sanity-typegen:setup": "chmod +x scripts/sanity-typegen",
+		"sanity:migrations:setup": "rm -rf migrations; ln -s lib/sanity/migrations migrations",
 		"format:write": "prettier . --write",
 		"format:check": "prettier . --check"
 	},


### PR DESCRIPTION
Migrations are kept in a directory at lib/sanity/migrations but the cli expects them to be at /migrations. I'm adding a migration for ensuring specific documents exist as singletons, and a script to package.json to handle linking /lib/sanity/migrations to /migrations with a symlink.
