### PR TITLE
Merge changes in dev/sanity-scripts to master

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"preview": "astro preview",
 		"astro": "astro",
 		"pre-commit": "scripts/pre-commit",
-		"pre-commit:setup": "ln -f scripts/pre-commit .git/hooks/pre-commit; chmod +x .git/hooks/pre-commit",
+		"pre-commit:setup": "rm -rf ./git/hooks/pre-commit; ln -f scripts/pre-commit .git/hooks/pre-commit; chmod +x .git/hooks/pre-commit",
 		"sanity-typegen": "scripts/sanity-typegen",
 		"sanity-typegen:setup": "chmod +x scripts/sanity-typegen",
 		"sanity:migrations:setup": "rm -rf migrations; ln -s lib/sanity/migrations migrations",


### PR DESCRIPTION
Deleting the hook from ./git/hooks/pre-commit before re-linking avoids some unavoidable breakage in certain filesystems.
