### PR TITLE
fix: add rule to remove fill and stroke via svgo config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,8 +16,18 @@ export default defineConfig({
 			iconDir: "src/assets/icons",
 			svgoOptions: {
 				plugins: [
-					"preset-default",
-					{ name: "removeAttrs", params: { attrs: "(fill)" } },
+					{
+						name: "preset-default",
+						params: {
+							overrides: {
+								removeUselessStrokeAndFill: false,
+							},
+						},
+					},
+					{
+						name: "removeAttrs",
+						params: { attrs: "(fill|stroke)$" },
+					},
 				],
 			},
 		}),


### PR DESCRIPTION
The astro-icon plugin svgo configuration needs tweaking to remove fill and stroke from the translation output to allow for css styling.

I want to keep icon-specific attributes like stroke-width to maintain good design consistency. So I'm also disabling the removeUselessStrokeAndFill plugin in svgo.
