### PR TITLE
Merge dev/sanity-typegen with master

### DIFF
--- a/sanity-typegen.json
+++ b/sanity-typegen.json
@@ -1,4 +1,5 @@
 {
-	"schema": "src/lib/sanity/types/schema.json",
-	"generates": "src/lib/sanity/types/schema.ts"
+	"path": "./lib/sanity/**/*.{ts,tsx,js,jsx}",
+	"schema": "lib/sanity/types/schema.json",
+	"generates": "lib/sanity/types/schema.ts"
 }

--- a/scripts/sanity-typegen
+++ b/scripts/sanity-typegen
@@ -2,7 +2,7 @@
 
 echo "Running Sanity Typegen script..."
 
-SCHEMA_PATH=src/lib/sanity/types/schema.json
+SCHEMA_PATH=lib/sanity/types/schema.json
 
 npx sanity schema extract --path $SCHEMA_PATH --enforce-required-fields
 


### PR DESCRIPTION
Sanity schemas and types were moved to the lib folder. Typegen scripts were never updated to reflect this
