### PR TITLE
feat: persist nav-menu components across transitions

### DIFF
--- a/src/components/features/nav-menu/NavMenu.astro
+++ b/src/components/features/nav-menu/NavMenu.astro
@@ -5,3 +5,9 @@ import NavMenuOverlay from "./NavMenuOverlay.astro";
 
 <NavMenuOverlay />
 <NavMenuToggle />
+
+<script>
+	import { dispatch } from "@src/events/global/nav-menu";
+
+	document.addEventListener("astro:after-swap", () => dispatch("close"));
+</script>

--- a/src/components/features/nav-menu/NavMenuOverlay.astro
+++ b/src/components/features/nav-menu/NavMenuOverlay.astro
@@ -1,4 +1,4 @@
-<nav id="nav-menu">
+<nav id="nav-menu" transition:persist="nav-menu">
 	<ul>
 		<li><a href="/">Home</a></li>
 		<li><a href="/writings">Blog</a></li>
@@ -16,8 +16,6 @@
 
 	register("open", open);
 	register("close", close);
-
-	document.addEventListener("astro:after-swap", close);
 </script>
 
 <style>

--- a/src/components/features/nav-menu/NavMenuToggle.astro
+++ b/src/components/features/nav-menu/NavMenuToggle.astro
@@ -2,7 +2,7 @@
 import NavMenuIcon from "@src/components/icons/NavMenuIcon.astro";
 ---
 
-<button id="nav-menu__toggle">
+<button id="nav-menu__toggle" transition:persist="nav-menu__toggle">
 	<NavMenuIcon />
 </button>
 


### PR DESCRIPTION
Adding transition:persist to component attributes and adding an event listener to close the nav after page-swap
