### PR TITLE
feat: add metadata to layout and refactor

### DIFF
--- a/src/components/scripts/SetViewHeight.astro
+++ b/src/components/scripts/SetViewHeight.astro
@@ -1,13 +1,11 @@
-<script is:inline>
+<script>
 	function set() {
-		const h = window.innerHeight;
+		const h = document.documentElement.clientHeight;
 		document.documentElement.style.setProperty("--vh", `${h}px`);
+		console.log(h);
 	}
 
-	set();
-
-	document.addEventListener("astro:page-load", set);
-	document.addEventListener("DOMContentLoaded", set);
 	window.addEventListener("resize", set);
 	window.addEventListener("orientationchange", set);
+	document.addEventListener("astro:page-load", set);
 </script>

--- a/src/layouts/Body.astro
+++ b/src/layouts/Body.astro
@@ -6,9 +6,9 @@
 		min-height: 100dvh;
 		min-height: var(--vh, 100vh);
 
-		color: theme(colors.base.dark.text.1);
+		color: theme(colors.base.dark.text.default);
 
-		overscroll-behavior: none;
+		/* overscroll-behavior: */
 		overflow-x: hidden;
 	}
 </style>

--- a/src/layouts/GeneratedMetaTags.astro
+++ b/src/layouts/GeneratedMetaTags.astro
@@ -1,0 +1,15 @@
+---
+import OptionalMetaTag from "@src/layouts/OptionalMetaTag.astro";
+
+type Props = {
+	metaDescription?: string;
+	metaKeywords?: string[];
+	metaAuthor?: string;
+};
+
+const { metaDescription, metaKeywords, metaAuthor } = Astro.props;
+---
+
+<OptionalMetaTag name="description" content={metaDescription} />
+<OptionalMetaTag name="keywords" content={metaKeywords?.join(",")} />
+<OptionalMetaTag name="author" content={metaAuthor} />

--- a/src/layouts/Html.astro
+++ b/src/layouts/Html.astro
@@ -2,11 +2,7 @@
 
 <style is:global>
 	html {
-		background-image: linear-gradient(
-			to top right,
-			theme(colors.base.dark.1),
-			theme(colors.base.dark.2)
-		);
+		background: #080808;
 		background-size: cover;
 		background-attachment: fixed;
 	}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,8 +1,11 @@
 ---
-import { ClientRouter } from "astro:transitions";
 import Body from "@src/layouts/Body.astro";
 import Html from "@src/layouts/Html.astro";
-import SetViewportHeight from "@src/components/scripts/SetViewportHeight.astro";
+import Title from "@src/layouts/Title.astro";
+import SharedMetaTags from "@src/layouts/SharedMetaTags.astro";
+import GeneratedMetaTags from "@src/layouts/GeneratedMetaTags.astro";
+import SharedLinks from "@src/layouts/SharedLinks.astro";
+import SharedScripts from "@src/layouts/SharedScripts.astro";
 
 import DosisProvider from "@src/components/fonts/DosisProvider.astro";
 import IcebergProvider from "@src/components/fonts/IcebergProvider.astro";
@@ -10,48 +13,19 @@ import MichromaProvider from "@src/components/fonts/MichromaProvider.astro";
 import BoldonseProvider from "@src/components/fonts/BoldonseProvider.astro";
 import Jersey15Provider from "@src/components/fonts/Jersey15Provider.astro";
 
-import { getSettings } from "lib/sanity/fetch";
-
-export interface Props {
+type Props = {
 	pageTitle?: string;
 	metaDescription?: string;
 	metaKeywords?: string[];
 	metaAuthor?: string;
-}
+};
 
 const { pageTitle, metaDescription, metaKeywords, metaAuthor } = Astro.props;
-
-const settingsData = await getSettings();
-const main_title = settingsData?.main_title || "Main Title";
-
-const title = `${main_title}${pageTitle ? ` | ${pageTitle}` : ""}`;
 ---
 
 <Html>
 	<head>
-		<title>{title}</title>
-
-		<!-- Shared Meta Tags -->
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<meta name="generator" content={Astro.generator} />
-		<meta name="theme-color" content="#000000" />
-
-		<!-- Generated Meta Tags -->
-		{
-			metaDescription ? (
-				<meta name="description" content={metaDescription} />
-			) : null
-		}
-		{
-			metaKeywords ? (
-				<meta name="keywords" content={metaKeywords.join(", ")} />
-			) : null
-		}
-		{metaAuthor ? <meta name="author" content={metaAuthor} /> : null}
-
-		<!-- Links -->
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<Title subtitle={pageTitle} />
 
 		<!-- Font Providers -->
 		<DosisProvider />
@@ -60,9 +34,14 @@ const title = `${main_title}${pageTitle ? ` | ${pageTitle}` : ""}`;
 		<BoldonseProvider />
 		<Jersey15Provider />
 
-		<!-- Client Scripts -->
-		<ClientRouter fallback="swap" />
-		<SetViewportHeight />
+		<SharedMetaTags />
+		<GeneratedMetaTags
+			metaDescription={metaDescription}
+			metaKeywords={metaKeywords}
+			metaAuthor={metaAuthor}
+		/>
+		<SharedLinks />
+		<SharedScripts />
 	</head>
 
 	<Body>

--- a/src/layouts/OptionalMetaTag.astro
+++ b/src/layouts/OptionalMetaTag.astro
@@ -1,0 +1,8 @@
+---
+type Props = (
+	| { name: string; "http-equiv"?: never }
+	| { name?: never; "http-equiv": string }
+) & { content?: string };
+---
+
+{Astro.props.content ? <meta {...Astro.props} /> : null}

--- a/src/layouts/SharedLinks.astro
+++ b/src/layouts/SharedLinks.astro
@@ -1,0 +1,2 @@
+<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<link rel="manifest" href="/manifest.webmanifest" />

--- a/src/layouts/SharedMetaTags.astro
+++ b/src/layouts/SharedMetaTags.astro
@@ -1,0 +1,4 @@
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta name="generator" content={Astro.generator} />
+<meta name="theme-color" content="#000000" />

--- a/src/layouts/SharedScripts.astro
+++ b/src/layouts/SharedScripts.astro
@@ -1,0 +1,7 @@
+---
+import ClientRouter from "astro/components/ClientRouter.astro";
+import SetViewHeight from "@src/components/scripts/SetViewHeight.astro";
+---
+
+<ClientRouter fallback="swap" />
+<SetViewHeight />

--- a/src/layouts/Title.astro
+++ b/src/layouts/Title.astro
@@ -1,0 +1,14 @@
+---
+import { getSettings } from "lib/sanity/fetch";
+
+type Props = {
+	subtitle?: string;
+};
+
+const { subtitle } = Astro.props;
+
+let title = (await getSettings())?.main_title || "Site Title";
+title += subtitle ? ` | ${subtitle}` : "";
+---
+
+<title>{title}</title>


### PR DESCRIPTION
Refactoring the main layout component to split scripts, links, and meta tags. Adding meta tags for SEO
