### PR TITLE
feat: change metadata keywords to a string array

### DIFF
--- a/src/layouts/GeneratedMetaTags.astro
+++ b/src/layouts/GeneratedMetaTags.astro
@@ -17,7 +17,7 @@ const {
 {abstract ? <meta name="abstract" content={abstract} /> : null}
 {author ? <meta name="author" content={author} /> : null}
 {description ? <meta name="description" content={description} /> : null}
-{keywords ? <meta name="keywords" content={keywords} /> : null}
+{keywords ? <meta name="keywords" content={keywords?.join(",")} /> : null}
 {robots ? <meta name="robots" content={robots} /> : null}
 
 {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export type Metadata = {
 	abstract?: string;
 	author?: string;
 	description?: string;
-	keywords?: string;
+	keywords?: string[];
 	robots?: string;
 	httpContentType?: string;
 	httpRefresh?: string;


### PR DESCRIPTION
Forcing a string array makes it easier to format it correctly before injection
