### PR TITLE
feature: add icon class props

### DIFF
--- a/src/components/ProgressNotification.astro
+++ b/src/components/ProgressNotification.astro
@@ -47,6 +47,7 @@ const urlPath = Astro.url.pathname;
 					codepen={codepen}
 					shadertoy={shadertoy}
 					email={email}
+					class="*:fill-gray-400 hover:*:fill-gray-300 *:duration-200"
 				/>
 			</div>
 		) : null

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -73,15 +73,3 @@ const {
 		</a>
 	) : null
 }
-
-<style>
-	/* Default style */
-	:global(svg) {
-		fill: gray;
-		transition: 200ms ease-in-out;
-
-		&:hover {
-			fill: lightgray;
-		}
-	}
-</style>

--- a/src/components/icons/CodepenIcon.astro
+++ b/src/components/icons/CodepenIcon.astro
@@ -1,5 +1,12 @@
 ---
 import Icon from "./Icon.astro";
+
+type Props = {
+	class?: string;
+	id?: string;
+};
+
+const { class: className, id } = Astro.props;
 ---
 
-<Icon name="codepen" />
+<Icon name="codepen" class={className} id={id} />

--- a/src/components/icons/EmailIcon.astro
+++ b/src/components/icons/EmailIcon.astro
@@ -1,5 +1,12 @@
 ---
 import Icon from "./Icon.astro";
+
+type Props = {
+	class?: string;
+	id?: string;
+};
+
+const { class: className, id } = Astro.props;
 ---
 
-<Icon name="email" />
+<Icon name="email" class={className} id={id} />

--- a/src/components/icons/FacebookIcon.astro
+++ b/src/components/icons/FacebookIcon.astro
@@ -1,5 +1,12 @@
 ---
 import Icon from "./Icon.astro";
+
+type Props = {
+	class?: string;
+	id?: string;
+};
+
+const { class: className, id } = Astro.props;
 ---
 
-<Icon name="facebook" />
+<Icon name="facebook" class={className} id={id} />

--- a/src/components/icons/GithubIcon.astro
+++ b/src/components/icons/GithubIcon.astro
@@ -1,5 +1,12 @@
 ---
 import Icon from "./Icon.astro";
+
+type Props = {
+	class?: string;
+	id?: string;
+};
+
+const { class: className, id } = Astro.props;
 ---
 
-<Icon name="github" />
+<Icon name="github" class={className} id={id} />

--- a/src/components/icons/Icon.astro
+++ b/src/components/icons/Icon.astro
@@ -2,20 +2,12 @@
 import { Icon as AstroIcon } from "astro-icon/components";
 
 export interface Props {
-	/** Name of the icon. Maps directly to the svg filename in the icons directory. */
 	name: string;
-	/** Sets width and height of the svg style to 100%. */
-	fillContainer?: boolean;
+	class?: string;
+	id?: string;
 }
 
-const { name, fillContainer } = Astro.props;
+const { name, class: className, id } = Astro.props;
 ---
 
-<AstroIcon name={name} class:list={[fillContainer && "fullsize"]} />
-
-<style>
-	.fullsize {
-		width: 100%;
-		height: 100%;
-	}
-</style>
+<AstroIcon name={name} id={id} class={className} />

--- a/src/components/icons/LinkedinIcon.astro
+++ b/src/components/icons/LinkedinIcon.astro
@@ -1,5 +1,12 @@
 ---
 import Icon from "./Icon.astro";
+
+type Props = {
+	class?: string;
+	id?: string;
+};
+
+const { class: className, id } = Astro.props;
 ---
 
-<Icon name="linkedin" />
+<Icon name="linkedin" class={className} id={id} />

--- a/src/components/icons/ShadertoyIcon.astro
+++ b/src/components/icons/ShadertoyIcon.astro
@@ -1,5 +1,12 @@
 ---
 import Icon from "./Icon.astro";
+
+type Props = {
+	class?: string;
+	id?: string;
+};
+
+const { class: className, id } = Astro.props;
 ---
 
-<Icon name="shadertoy" />
+<Icon name="shadertoy" class={className} id={id} />


### PR DESCRIPTION
Removing the stupid fillContainer prop from icon. Switching back to using tailwind classes so class strings can be passed through, negating the use of it. Also updating some consuming components accordingly.
