### PR TITLE
refactor: update nav menu styles to use data-nav-open attribute on the body

### DIFF
--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -1,14 +1,14 @@
 ---
 import SiteIcon from "@src/components/icons/SiteIcon.astro";
 import NavMenuToggle from "@src/components/features/nav-menu/NavMenuToggle.astro";
+import NavMenuIcon from "@src/components/icons/NavMenuIcon.astro";
 ---
 
-<header class="w-full h-16 p-4 fixed z-40 flex justify-between">
+<header class="w-full h-24 p-8 fixed z-40 flex justify-between">
 	<a href="/">
 		<SiteIcon class="h-full fill-none stroke-base-dark-text-default" />
 	</a>
-
-	<NavMenuToggle
-		class="h-full aspect-square fill-none stroke-base-dark-text-default"
-	/>
+	<NavMenuToggle class="h-full aspect-square">
+		<NavMenuIcon class="fill-none stroke-base-dark-text-default" />
+	</NavMenuToggle>
 </header>

--- a/src/components/features/nav-menu/NavMenu.astro
+++ b/src/components/features/nav-menu/NavMenu.astro
@@ -3,31 +3,30 @@ import NavMenuShutter from "@src/components/features/nav-menu/NavMenuShutter.ast
 import NavMenuOverlay from "@src/components/features/nav-menu/NavMenuOverlay.astro";
 ---
 
-<div
-	id="nav-menu"
-	class="fixed top-0 bottom-0 left-0 right-0 pointer-events-none z-40">
+<div class="fixed top-0 bottom-0 left-0 right-0 pointer-events-none z-40">
 	<NavMenuShutter class="w-full h-full" />
-	<NavMenuOverlay id="nav-menu__overlay" />
+	<NavMenuOverlay />
 </div>
 
 <script>
 	import { navMenuStore } from "@src/stores";
 
-	const load = () => {
-		const $menu = document.querySelector(
-			"#nav-menu__overlay",
-		) as HTMLElement;
-
-		navMenuStore.subscribe((value, oldValue, changed) => {
-			if (changed === "open") {
-				value.open === true
-					? $menu.setAttribute("data-open", "true")
-					: $menu.removeAttribute("data-open");
-			}
-		});
+	const updateBody = (body: HTMLElement) => {
+		navMenuStore.read().open
+			? body.setAttribute("data-nav-open", "true")
+			: body.removeAttribute("data-nav-open");
 	};
 
-	document.addEventListener("load", load);
-	document.addEventListener("astro:page-load", load);
+	navMenuStore.subscribe((value, oldValue, changed) => {
+		if (changed === "open") {
+			value.open === true
+				? document.body.setAttribute("data-nav-open", "true")
+				: document.body.removeAttribute("data-nav-open");
+		}
+	});
+
+	document.addEventListener("astro:before-swap", ({ newDocument }) => {
+		updateBody(newDocument.body);
+	});
 	document.addEventListener("astro:page-load", navMenuStore.actions.close);
 </script>

--- a/src/components/features/nav-menu/NavMenuOverlay.astro
+++ b/src/components/features/nav-menu/NavMenuOverlay.astro
@@ -1,15 +1,6 @@
----
-type Props = {
-	id?: string;
-};
-
-const { id } = Astro.props;
----
-
 <nav
-	id={id}
 	class="fixed left-0 right-0 top-0 bottom-0 flex justify-end items-center"
-	transition:persist={id}>
+	transition:persist="nav-menu__overlay">
 	<ul class="font-michroma flex flex-col gap-4 m-2 z-10">
 		<li><a href="/">Home</a></li>
 		<li><a href="/blog">Blog</a></li>
@@ -19,7 +10,7 @@ const { id } = Astro.props;
 </nav>
 
 <style>
-	nav[data-open] {
+	body[data-nav-open] nav {
 		pointer-events: all;
 		& ul {
 			transition-delay: 250ms;

--- a/src/components/features/nav-menu/NavMenuShutter.astro
+++ b/src/components/features/nav-menu/NavMenuShutter.astro
@@ -15,28 +15,19 @@ const { class: className } = Astro.props;
 	import { navMenuStore } from "@src/stores";
 	import NavMenuShutterRenderer from "@src/webgl/NavMenuShutterRenderer";
 
-	let renderer: NavMenuShutterRenderer | null = null;
+	const $shutter = document.querySelector(
+		"#nav-menu__shutter",
+	) as HTMLCanvasElement;
 
-	const load = () => {
-		const $shutter = document.querySelector(
-			"#nav-menu__shutter",
-		) as HTMLCanvasElement;
+	const renderer = new NavMenuShutterRenderer($shutter, {
+		verticalCells: 40,
+	});
 
-		if (!renderer) {
-			renderer = new NavMenuShutterRenderer($shutter, {
-				verticalCells: 40,
-			});
+	navMenuStore.subscribe((value, oldValue, changed) => {
+		if (changed === "open") {
+			value.open === true ? renderer.open() : renderer.close();
 		}
+	});
 
-		navMenuStore.subscribe((value, oldValue, changed) => {
-			if (changed === "open") {
-				value.open === true ? renderer!.open() : renderer?.close();
-			}
-		});
-
-		window.addEventListener("resize", renderer.resize);
-	};
-
-	document.addEventListener("DOMContentLoaded", load);
-	document.addEventListener("astro:page-load", load);
+	window.addEventListener("resize", renderer.resize);
 </script>

--- a/src/components/features/nav-menu/NavMenuToggle.astro
+++ b/src/components/features/nav-menu/NavMenuToggle.astro
@@ -1,6 +1,4 @@
 ---
-import NavMenuIcon from "@src/components/icons/NavMenuIcon.astro";
-
 type Props = {
 	/** Disables the toggle. Enabling it can be done via the nav-menu event dispatcher. */
 	disabled?: boolean;
@@ -12,35 +10,18 @@ const { disabled, class: className } = Astro.props;
 
 <button
 	id="nav-menu__toggle"
+	transition:persist="nav-menu__toggle"
 	class={className}
-	disabled={disabled}
-	transition:persist="nav-menu__toggle">
-	<NavMenuIcon id="nav-menu__icon" />
+	disabled={disabled}>
+	<slot />
 </button>
 
 <script>
 	import { navMenuStore } from "@src/stores";
 
-	const load = () => {
-		const $toggle = document.querySelector(
-			"#nav-menu__toggle",
-		) as HTMLButtonElement;
-		const $icon = document.querySelector("#nav-menu__icon") as HTMLElement;
+	const $toggle = document.querySelector(
+		"#nav-menu__toggle",
+	) as HTMLButtonElement;
 
-		const unsubscribe = navMenuStore.subscribe(
-			(value, oldValue, changed) => {
-				if (changed === undefined || changed === "open") {
-					value.open === true
-						? $icon.setAttribute("data-open", "true")
-						: $icon.removeAttribute("data-open");
-				}
-			},
-		);
-
-		$toggle.addEventListener("click", navMenuStore.actions.toggle);
-		document.addEventListener("astro:before-preparation", unsubscribe);
-	};
-
-	window.addEventListener("load", load);
-	document.addEventListener("astro:page-load", load);
+	$toggle.addEventListener("click", navMenuStore.actions.toggle);
 </script>

--- a/src/components/icons/NavMenuIcon.astro
+++ b/src/components/icons/NavMenuIcon.astro
@@ -1,15 +1,15 @@
 ---
 type Props = {
-	id?: string;
+	class?: string;
 };
 
-const { id } = Astro.props;
+const { class: className } = Astro.props;
 ---
 
 <svg
-	id={id}
-	class="-translate-y-1/3 fill-none stroke-base-dark-text-default stroke-1 pointer-events-none"
-	viewBox="0 -32 32 96">
+	class={className}
+	viewBox="0 -32 32 96"
+	transition:persist="nav-menu__icon">
 	<g>
 		<path d="M 2,10 L 8,6 L 30,6 L 24,10 Z"></path>
 		<path d="M 2,18 L 8,14 L 30,14 L 24,18 Z"></path>
@@ -23,6 +23,11 @@ const { id } = Astro.props;
 </svg>
 
 <style>
+	svg {
+		transform: translateY(-33.333%);
+		pointer-events: none;
+	}
+
 	svg > g:nth-child(1) {
 		& path {
 			transition: 200ms ease-in-out;
@@ -39,7 +44,7 @@ const { id } = Astro.props;
 		}
 	}
 
-	svg[data-open] > g:nth-child(1) {
+	body[data-nav-open] svg > g:nth-child(1) {
 		& path {
 			transform: translateY(32px);
 			opacity: 0;
@@ -71,7 +76,7 @@ const { id } = Astro.props;
 		}
 	}
 
-	svg[data-open] > g:nth-child(2) {
+	body[data-nav-open] svg > g:nth-child(2) {
 		& path {
 			transform: translateY(0);
 			opacity: 1;


### PR DESCRIPTION
Changing to make more reliable. Using scripts for individual components to set their data-open attribute is dumb.
